### PR TITLE
Organize each search into dedicated run directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@
 
 ## 快速开始
 下面的示例从 ICLR 2025 与 NeurIPS 2024 两个会场检索包含 “reinforcement learning” 的论文，
-将 PDF 保存至 `papers` 目录，并以 IEEE 风格生成参考文献：
+结果会创建一个新的运行目录（如 `runs/20250628_120000`），其中包含 PDF、查询信息与参考文献：
 ```bash
 python download_openreview_papers.py \
   --query "reinforcement learning" \
   --venues ICLR.cc/2025/Conference NeurIPS.cc/2024/Conference \
   --style ieee \
-  --out papers \
+  --out runs \
+  --run-name 20250628_120000 \
   --max 40
 ```
 
@@ -41,7 +42,8 @@ python download_openreview_papers.py \
 | ---- | ---- |
 | `--query` | 必填，关键词或正则表达式，匹配论文标题或摘要（忽略大小写）。 |
 | `--venues` | 必填，OpenReview 会场 ID，可同时指定多个，如 `ICLR.cc/2025/Conference`。 |
-| `--out` | PDF 保存目录，默认 `papers`。 |
+| `--out` | 用于存放运行目录的父路径，默认 `runs`。 |
+| `--run-name` | 运行目录名称，默认为当前时间戳。 |
 | `--style` | 参考文献格式，可选 `gb7714`（默认）或 `ieee`。 |
 | `--max` | 限制最多下载 N 篇论文。 |
 | `--include-submitted` | 包括仍在评审或已撤稿的投稿。 |
@@ -55,17 +57,17 @@ python download_openreview_papers.py \
 
 ```bash
 export DEEPSEEK_API_KEY="your_api_key"
-python summarize_papers.py papers --out summaries
+python summarize_papers.py runs/20250628_120000/papers
 ```
 
 
 
 ## 根据摘要生成 PPT
 
-`generate_ppt.py` 会读取 `summaries` 目录下的 JSON 文件，将摘要内容直接填入 `template.pptx` 模板，并在每张幻灯片右下角自动添加页码。
+`generate_ppt.py` 会读取运行目录内 `summaries` 子目录的 JSON 文件，将摘要内容直接填入 `template.pptx` 模板，并在每张幻灯片右下角自动添加页码。
 
 ```bash
-python generate_ppt.py summaries --out slides.pptx
+python generate_ppt.py runs/20250628_120000/summaries --out slides.pptx
 ```
 
 ## 更新日志

--- a/summarize_papers.py
+++ b/summarize_papers.py
@@ -140,14 +140,17 @@ def main(argv: List[str] | None = None) -> None:
     p.add_argument("path", type=Path, help="包含 PDF 的目录")
     p.add_argument("--api-key", dest="api_key",
                    help="DeepSeek API key；若省略读取 DEEPSEEK_API_KEY 环境变量")
-    p.add_argument("--out", type=Path, default=Path("summaries"),
-                   help="JSON 输出目录，默认 ./summaries")
+    p.add_argument("--out", type=Path, default=None,
+                   help="JSON 输出目录，默认 <path>/summaries")
     args = p.parse_args(argv)
 
     api_key = args.api_key or os.getenv("DEEPSEEK_API_KEY")
     if not api_key:
         p.error("必须提供 DeepSeek API key (--api-key 或环境变量 )")
     client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com")
+
+    if args.out is None:
+        args.out = args.path.parent / "summaries"
 
     pdfs = sorted(args.path.rglob("*.pdf"))
     if not pdfs:
@@ -171,6 +174,8 @@ def main(argv: List[str] | None = None) -> None:
         out_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2),
                             encoding="utf-8")
         tqdm.write(f"✅ {pdf.stem}.json 已保存")
+
+    print(f"✔ 摘要已保存至 {args.out}")
 
 if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
## Summary
- add `--run-name` option and auto timestamped output folders in `download_openreview_papers.py`
- store query/venue metadata and references within the run directory
- default summary output to `<path>/summaries`
- update README with new run directory workflow

## Testing
- `python -m py_compile download_openreview_papers.py summarize_papers.py generate_ppt.py`


------
https://chatgpt.com/codex/tasks/task_e_6860da5a62688326be53654aa4318c36